### PR TITLE
gauss: Fix bug on guides with zero cells

### DIFF
--- a/crispat/gauss.py
+++ b/crispat/gauss.py
@@ -325,11 +325,13 @@ def ga_gauss(input_file, output_dir, start_gRNA = 0, step = None, batch_list = N
                 perturbed_cells, threshold, loss, map_estimates = fit_GMM(gRNA, adata_crispr_batch, 
                                                                           output_dir + 'batch' + str(batch) + '/', 
                                                                           2024, n_iter, nonzero)
-                if len(perturbed_cells) != 0:
-                    df = pd.DataFrame({'cell': perturbed_cells, 'gRNA': gRNA})
-                    thresholds = pd.concat([thresholds, pd.DataFrame({'gRNA': [gRNA], 'threshold': [threshold]})])
-                    losses = pd.concat([losses, pd.DataFrame({'gRNA': [gRNA], 'loss': [loss]})])
-                    estimates = pd.concat([estimates, map_estimates])
+                if len(perturbed_cells) == 0:
+                    continue
+
+                df = pd.DataFrame({'cell': perturbed_cells, 'gRNA': gRNA})
+                thresholds = pd.concat([thresholds, pd.DataFrame({'gRNA': [gRNA], 'threshold': [threshold]})])
+                losses = pd.concat([losses, pd.DataFrame({'gRNA': [gRNA], 'loss': [loss]})])
+                estimates = pd.concat([estimates, map_estimates])
             elif inference == "em":
                 df = fit_em(gRNA, adata_crispr_batch, nonzero)
                 


### PR DESCRIPTION
ga_gauss has an error with guides that have zero cells.

If the first guide has zero cells it will crash, here is a minimal example:
```
import crispat

import numpy as np
import anndata as ad

import tempfile

adata = ad.AnnData(
    np.array(
        [[0, 0, 0, 0],
         [0, 1, 2, 3],
         [0, 2, 3, 4]]
    )
)

adata.obs_names = [f"cell_{i}" for i in range(adata.shape[0])]
adata.var_names = [f"grna_{i}" for i in range(adata.shape[1])]

adata.obs['batch'] = 'batch'

with tempfile.TemporaryDirectory() as tempdir:
    adata_path = os.path.join(tempdir, 'adata.h5ad')
    adata.write(adata_path)

    crispat.ga_gauss(adata_path,
                     tempdir)
```
which gives
```
UnboundLocalError: local variable 'df' referenced before assignment 
```
Otherwise, if the first guide isn't empty, it won't crash, but any empty guides will get the same assignments as the previous guide.

I believe this PR fixes the bug.