### PR TITLE
fix compatibility with numpy >= 2.0 in gauss and poisson_gauss

### DIFF
--- a/crispat/gauss.py
+++ b/crispat/gauss.py
@@ -222,7 +222,7 @@ def fit_GMM(gRNA, adata_crispr, output_dir, seed, n_iter, nonzero):
     plot_loss(losses, gRNA, output_dir)
     
     # threshold for which probability is higher to belong to the higher normal component
-    X = np.arange(1, max(selected_guide.toarray()) + 1, 1)
+    X = np.arange(1, int(selected_guide.max()) + 1, 1)
     log_X = np.log10(X + 1)
     df = pd.DataFrame({'t': X, 'prob_normal_component': prob_normal_component(log_X, weights, locs, scales)})
     threshold = df.loc[(df.prob_normal_component == True), 't'].min()

--- a/crispat/poisson_gauss.py
+++ b/crispat/poisson_gauss.py
@@ -252,7 +252,7 @@ def fit_PGMM(gRNA, adata_crispr, output_dir, seed, n_iter):
     plot_loss(losses, gRNA, output_dir)
     
     # threshold for which probability is higher to belong to the normal component
-    X = np.arange(1, max(selected_guide.toarray())+1, 1)
+    X = np.arange(1, int(selected_guide.max()) + 1, 1)
     log_X = np.log2(X)
     df = pd.DataFrame({'t': X, 'prob_normal_component': prob_normal_component(log_X, weights, mu, scale, lam)})
     threshold = df.loc[(df.prob_normal_component > 0.5), 't'].min()


### PR DESCRIPTION
max(sparse.toarray()) iterates rows and compares 1-D arrays, which raises TypeError under numpy >= 2.0. Use sparse.max() directly to get a scalar; backward compatible with numpy < 2.0.