### PR TITLE
add n_jobs and make_plots options to ga_gauss and ga_poisson_gauss

### DIFF
--- a/crispat/gauss.py
+++ b/crispat/gauss.py
@@ -155,7 +155,7 @@ def prob_normal_component(X, weights, locs, scales):
     return prob
 
 
-def fit_GMM(gRNA, adata_crispr, output_dir, seed, n_iter, nonzero):
+def fit_GMM(gRNA, adata_crispr, output_dir, seed, n_iter, nonzero, make_plots=True):
     '''
     Fits Gaussian mixture model for log2 of non-zero UMI counts of one gRNA using variational inference
     Args:
@@ -165,6 +165,7 @@ def fit_GMM(gRNA, adata_crispr, output_dir, seed, n_iter, nonzero):
         seed: (int) seed used for pyro
         n_iter (int, optional): number of steps for training the model
         nonzero (bool): if true fit the GMM on the nonzero values only
+        make_plots (bool): if False, skip writing per-gRNA loss and fitted-model PNGs (default True). Disable for batch / cluster runs to cut per-worker overhead.
     Returns:
         List of cells perturbed with the specified gRNA, as well as the inferred threshold
     '''
@@ -219,17 +220,19 @@ def fit_GMM(gRNA, adata_crispr, output_dir, seed, n_iter, nonzero):
                               'scale1': [scales],
                               'scale2': [scales]})
 
-    # create plot of the loss
-    plot_loss(losses, gRNA, output_dir)
-    
+    # create plot of the loss (skipped if make_plots is False)
+    if make_plots:
+        plot_loss(losses, gRNA, output_dir)
+
     # threshold for which probability is higher to belong to the higher normal component
     X = np.arange(1, int(selected_guide.max()) + 1, 1)
     log_X = np.log10(X + 1)
     df = pd.DataFrame({'t': X, 'prob_normal_component': prob_normal_component(log_X, weights, locs, scales)})
     threshold = df.loc[(df.prob_normal_component == True), 't'].min()
 
-    # create plot of the mixture distribution
-    plot_fitted_model(data, weights, locs, scales, np.log10(threshold+1), gRNA, output_dir)
+    # create plot of the mixture distribution (skipped if make_plots is False)
+    if make_plots:
+        plot_fitted_model(data, weights, locs, scales, np.log10(threshold+1), gRNA, output_dir)
     
     # get cells with gRNA counts above the threshold
     perturbed_cells = adata_crispr.obs_names[selected_guide.toarray().reshape(-1) >= threshold].tolist()
@@ -280,8 +283,8 @@ def _init_worker(adata):
     _WORKER_ADATA = adata
 
 
-def _fit_one_vi(gRNA, output_dir, seed, n_iter, nonzero):
-    return gRNA, fit_GMM(gRNA, _WORKER_ADATA, output_dir, seed, n_iter, nonzero)
+def _fit_one_vi(gRNA, output_dir, seed, n_iter, nonzero, make_plots):
+    return gRNA, fit_GMM(gRNA, _WORKER_ADATA, output_dir, seed, n_iter, nonzero, make_plots)
 
 
 def _fit_one_em(gRNA, nonzero):
@@ -289,7 +292,7 @@ def _fit_one_em(gRNA, nonzero):
 
 
 def ga_gauss(input_file, output_dir, start_gRNA = 0, step = None, batch_list = None, UMI_threshold = 0,
-                  n_iter = 250, nonzero = False, inference = "vi", n_jobs = 1):
+                  n_iter = 250, nonzero = False, inference = "vi", n_jobs = 1, make_plots = True):
     '''
     Guide assignment in which a Gaussian mixture model is fitted to the log-transformed UMI counts similar to the approach used in Cell Ranger. Two different inference methods are provided that can be selected with the 'inference' parameter.
 
@@ -304,6 +307,7 @@ def ga_gauss(input_file, output_dir, start_gRNA = 0, step = None, batch_list = N
         nonzero (bool, optional): if True fit the mixture model on the nonzero values only, otherwise all values are used
         inference (str): choice of the inference method, either "vi" (default) for variational inference via pyro or "em" for using an EM algorithm
         n_jobs (int, optional): number of worker processes used to fit gRNAs in parallel. Default 1 (serial). For n_jobs > 1, the per-gRNA model fits are dispatched to a process pool; results are reassembled in input order so output is identical to the serial run.
+        make_plots (bool, optional): if False, skip writing per-gRNA loss and fitted-model PNGs (only relevant for inference='vi'). Default True to preserve existing behavior. Set to False for batch / cluster runs to reduce per-worker overhead.
 
     Returns:
         None
@@ -321,8 +325,9 @@ def ga_gauss(input_file, output_dir, start_gRNA = 0, step = None, batch_list = N
         # If output_dir doesn't exist, the output folders are created
         if not os.path.exists(output_dir + 'batch' + str(batch) + '/'):
             os.makedirs(output_dir + 'batch' + str(batch) + '/')
-            os.makedirs(output_dir + 'batch' + str(batch) + "/fitted_model_plots/")
-            os.makedirs(output_dir + 'batch' + str(batch) + "/loss_plots/")
+            if make_plots:
+                os.makedirs(output_dir + 'batch' + str(batch) + "/fitted_model_plots/")
+                os.makedirs(output_dir + 'batch' + str(batch) + "/loss_plots/")
             #print("The output directory " + output_dir + 'batch' + str(batch) + '/' +  " was created")
 
         # Subset to selected batch
@@ -351,7 +356,7 @@ def ga_gauss(input_file, output_dir, start_gRNA = 0, step = None, batch_list = N
                 if inference == "vi":
                     fits[gRNA] = fit_GMM(gRNA, adata_crispr_batch,
                                          output_dir + 'batch' + str(batch) + '/',
-                                         2024, n_iter, nonzero)
+                                         2024, n_iter, nonzero, make_plots)
                 elif inference == "em":
                     fits[gRNA] = fit_em(gRNA, adata_crispr_batch, nonzero)
         else:
@@ -361,7 +366,7 @@ def ga_gauss(input_file, output_dir, start_gRNA = 0, step = None, batch_list = N
                 if inference == "vi":
                     futures = [ex.submit(_fit_one_vi, gRNA,
                                          output_dir + 'batch' + str(batch) + '/',
-                                         2024, n_iter, nonzero)
+                                         2024, n_iter, nonzero, make_plots)
                                for gRNA in gRNA_list]
                 elif inference == "em":
                     futures = [ex.submit(_fit_one_em, gRNA, nonzero)

--- a/crispat/gauss.py
+++ b/crispat/gauss.py
@@ -1,6 +1,7 @@
 import os
 import sys, getopt
 import json
+from concurrent.futures import ProcessPoolExecutor
 import numpy as np
 import pandas as pd
 import scanpy as sc
@@ -268,11 +269,30 @@ def fit_em(gRNA, adata_crispr, nonzero):
     return perturbations
 
     
+# Worker globals + helpers for n_jobs > 1. The AnnData is pickled once per
+# worker process via ProcessPoolExecutor's initializer (not per task), so we
+# avoid the cost of round-tripping it for every gRNA.
+_WORKER_ADATA = None
+
+
+def _init_worker(adata):
+    global _WORKER_ADATA
+    _WORKER_ADATA = adata
+
+
+def _fit_one_vi(gRNA, output_dir, seed, n_iter, nonzero):
+    return gRNA, fit_GMM(gRNA, _WORKER_ADATA, output_dir, seed, n_iter, nonzero)
+
+
+def _fit_one_em(gRNA, nonzero):
+    return gRNA, fit_em(gRNA, _WORKER_ADATA, nonzero)
+
+
 def ga_gauss(input_file, output_dir, start_gRNA = 0, step = None, batch_list = None, UMI_threshold = 0,
-                  n_iter = 250, nonzero = False, inference = "vi"):
+                  n_iter = 250, nonzero = False, inference = "vi", n_jobs = 1):
     '''
-    Guide assignment in which a Gaussian mixture model is fitted to the log-transformed UMI counts similar to the approach used in Cell Ranger. Two different inference methods are provided that can be selected with the 'inference' parameter.  
-    
+    Guide assignment in which a Gaussian mixture model is fitted to the log-transformed UMI counts similar to the approach used in Cell Ranger. Two different inference methods are provided that can be selected with the 'inference' parameter.
+
     Args:
         input_file (str): path to the stored anndata object with the gRNA counts
         output_dir (str): directory in which to store the resulting assignment
@@ -283,10 +303,11 @@ def ga_gauss(input_file, output_dir, start_gRNA = 0, step = None, batch_list = N
         n_iter (int, optional): number of steps for training the model
         nonzero (bool, optional): if True fit the mixture model on the nonzero values only, otherwise all values are used
         inference (str): choice of the inference method, either "vi" (default) for variational inference via pyro or "em" for using an EM algorithm
-    
+        n_jobs (int, optional): number of worker processes used to fit gRNAs in parallel. Default 1 (serial). For n_jobs > 1, the per-gRNA model fits are dispatched to a process pool; results are reassembled in input order so output is identical to the serial run.
+
     Returns:
         None
-    ''' 
+    '''
     print('Guide assignment using a Gaussian mixture model per batch')
     # Load gRNA counts data
     print('Load gRNA counts')
@@ -320,11 +341,38 @@ def ga_gauss(input_file, output_dir, start_gRNA = 0, step = None, batch_list = N
         losses = pd.DataFrame({'gRNA': [], 'loss': []})
         estimates = pd.DataFrame()
 
+        # Compute per-gRNA fit results, either serially (n_jobs=1, original
+        # code path, byte-identical to upstream) or via a process pool.
+        # Either way we end up with a dict keyed by gRNA so we can iterate
+        # gRNA_list in order below for deterministic concat.
+        fits = {}
+        if n_jobs == 1:
+            for gRNA in gRNA_list:
+                if inference == "vi":
+                    fits[gRNA] = fit_GMM(gRNA, adata_crispr_batch,
+                                         output_dir + 'batch' + str(batch) + '/',
+                                         2024, n_iter, nonzero)
+                elif inference == "em":
+                    fits[gRNA] = fit_em(gRNA, adata_crispr_batch, nonzero)
+        else:
+            with ProcessPoolExecutor(max_workers=n_jobs,
+                                     initializer=_init_worker,
+                                     initargs=(adata_crispr_batch,)) as ex:
+                if inference == "vi":
+                    futures = [ex.submit(_fit_one_vi, gRNA,
+                                         output_dir + 'batch' + str(batch) + '/',
+                                         2024, n_iter, nonzero)
+                               for gRNA in gRNA_list]
+                elif inference == "em":
+                    futures = [ex.submit(_fit_one_em, gRNA, nonzero)
+                               for gRNA in gRNA_list]
+                for fut in futures:
+                    gRNA, payload = fut.result()
+                    fits[gRNA] = payload
+
         for gRNA in gRNA_list:
             if inference == "vi":
-                perturbed_cells, threshold, loss, map_estimates = fit_GMM(gRNA, adata_crispr_batch, 
-                                                                          output_dir + 'batch' + str(batch) + '/', 
-                                                                          2024, n_iter, nonzero)
+                perturbed_cells, threshold, loss, map_estimates = fits[gRNA]
                 if len(perturbed_cells) == 0:
                     continue
 
@@ -333,8 +381,8 @@ def ga_gauss(input_file, output_dir, start_gRNA = 0, step = None, batch_list = N
                 losses = pd.concat([losses, pd.DataFrame({'gRNA': [gRNA], 'loss': [loss]})])
                 estimates = pd.concat([estimates, map_estimates])
             elif inference == "em":
-                df = fit_em(gRNA, adata_crispr_batch, nonzero)
-                
+                df = fits[gRNA]
+
             # get UMI_counts of assigned cells
             UMI_counts = adata_crispr_batch[df['cell'], [gRNA]].X.toarray().reshape(-1)
             df['UMI_counts'] = UMI_counts

--- a/crispat/poisson_gauss.py
+++ b/crispat/poisson_gauss.py
@@ -1,6 +1,7 @@
 import os
 import sys, getopt
 import json
+from concurrent.futures import ProcessPoolExecutor
 import numpy as np
 import pandas as pd
 import scanpy as sc
@@ -265,10 +266,24 @@ def fit_PGMM(gRNA, adata_crispr, output_dir, seed, n_iter):
     return(perturbed_cells, threshold, losses[-1], estimates)
 
 
-def ga_poisson_gauss(input_file, output_dir, start_gRNA = 0, step = None, n_iter = 500, n_counts = None, UMI_threshold = 0):
+# Worker globals + helpers for n_jobs > 1. AnnData is pickled once per
+# worker process via ProcessPoolExecutor's initializer, not per task.
+_WORKER_ADATA = None
+
+
+def _init_worker(adata):
+    global _WORKER_ADATA
+    _WORKER_ADATA = adata
+
+
+def _fit_one(gRNA, output_dir, seed, n_iter):
+    return gRNA, fit_PGMM(gRNA, _WORKER_ADATA, output_dir, seed, n_iter)
+
+
+def ga_poisson_gauss(input_file, output_dir, start_gRNA = 0, step = None, n_iter = 500, n_counts = None, UMI_threshold = 0, n_jobs = 1):
     '''
     Guide assignment in which a Poisson-Gaussian mixture model is fitted to the non-zero log-transformed UMI counts
-    
+
     Args:
         input_file (str): path to the stored anndata object with the gRNA counts
         output_dir (str): directory in which to store the resulting assignment
@@ -277,10 +292,11 @@ def ga_poisson_gauss(input_file, output_dir, start_gRNA = 0, step = None, n_iter
         n_iter (int, optional): number of steps for training the model
         n_counts (int, optional): subsample the gRNA counts per cell to a total of n_counts. If None (default), the UMI count matrix is used without any downsampling.
         UMI_threshold (int, optional): Additional UMI threshold for assigned cells which is applied after creating the initial assignment to remove cells with fewer UMI counts than this threshold (default: no additional UMI threshold)
-        
+        n_jobs (int, optional): number of worker processes used to fit gRNAs in parallel. Default 1 (serial). For n_jobs > 1, per-gRNA fits are dispatched to a process pool; results are reassembled in input order so output is identical to the serial run.
+
     Returns:
         None
-    '''   
+    '''
     print('Guide assignment with Poisson-Gaussian mixture model as in Replogle et al.')
     # If output_dir doesn't exist, the output folders are created
     if not os.path.exists(output_dir):
@@ -311,9 +327,27 @@ def ga_poisson_gauss(input_file, output_dir, start_gRNA = 0, step = None, n_iter
     estimates = pd.DataFrame()
     
     print('Fit Poisson-Gaussian Mixture Model for each gRNA: ')
-    for gRNA in tqdm(gRNA_list):
-        time.sleep(0.01)
-        perturbed_cells, threshold, loss, map_estimates = fit_PGMM(gRNA, adata_crispr, output_dir, 2024, n_iter)
+    # Compute per-gRNA fit results, either serially (n_jobs=1, original code
+    # path, byte-identical to upstream) or via a process pool. We collect into
+    # a dict and iterate gRNA_list in order below so concat order is
+    # deterministic regardless of n_jobs.
+    fits = {}
+    if n_jobs == 1:
+        for gRNA in tqdm(gRNA_list):
+            time.sleep(0.01)
+            fits[gRNA] = fit_PGMM(gRNA, adata_crispr, output_dir, 2024, n_iter)
+    else:
+        with ProcessPoolExecutor(max_workers=n_jobs,
+                                 initializer=_init_worker,
+                                 initargs=(adata_crispr,)) as ex:
+            futures = [ex.submit(_fit_one, gRNA, output_dir, 2024, n_iter)
+                       for gRNA in gRNA_list]
+            for fut in tqdm(futures):
+                gRNA, payload = fut.result()
+                fits[gRNA] = payload
+
+    for gRNA in gRNA_list:
+        perturbed_cells, threshold, loss, map_estimates = fits[gRNA]
         if len(perturbed_cells) != 0:
             # get UMI_counts of assigned cells
             UMI_counts = adata_crispr[perturbed_cells, [gRNA]].X.toarray().reshape(-1)

--- a/crispat/poisson_gauss.py
+++ b/crispat/poisson_gauss.py
@@ -185,17 +185,18 @@ def prob_normal_component(X, weights, mu, scale, lam):
     return prob
     
 
-def fit_PGMM(gRNA, adata_crispr, output_dir, seed, n_iter):
+def fit_PGMM(gRNA, adata_crispr, output_dir, seed, n_iter, make_plots=True):
     '''
-    Fits Poisson-Gaussian mixture model for log2 of non-zero UMI counts of one gRNA 
-    
+    Fits Poisson-Gaussian mixture model for log2 of non-zero UMI counts of one gRNA
+
     Args:
         gRNA (str): name of the gRNA
         adata_crispr (AnnData): anndata object with UMI counts of CRISPR Guide Capture
         output_dir (str): directory in which the resulting plots will be saved
         seed (int): seed used for pyro
         n_iter (int): number of steps for training the model
-        
+        make_plots (bool): if False, skip writing per-gRNA loss and fitted-model PNGs (default True). Disable for batch / cluster runs to cut per-worker overhead.
+
     Returns:
         List of cells perturbed with the specified gRNA, as well as the inferred threshold
     '''
@@ -249,17 +250,19 @@ def fit_PGMM(gRNA, adata_crispr, output_dir, seed, n_iter):
                               'mu': [mu], 
                               'scale': [scale]})
 
-    # create plot of the loss
-    plot_loss(losses, gRNA, output_dir)
-    
+    # create plot of the loss (skipped if make_plots is False)
+    if make_plots:
+        plot_loss(losses, gRNA, output_dir)
+
     # threshold for which probability is higher to belong to the normal component
     X = np.arange(1, int(selected_guide.max()) + 1, 1)
     log_X = np.log2(X)
     df = pd.DataFrame({'t': X, 'prob_normal_component': prob_normal_component(log_X, weights, mu, scale, lam)})
     threshold = df.loc[(df.prob_normal_component > 0.5), 't'].min()
-    
-    # create plot of the mixture distribution
-    plot_fitted_model(data, weights, mu, scale, lam, np.log2(threshold), gRNA, output_dir)
+
+    # create plot of the mixture distribution (skipped if make_plots is False)
+    if make_plots:
+        plot_fitted_model(data, weights, mu, scale, lam, np.log2(threshold), gRNA, output_dir)
     
     # get cells with gRNA counts above the threshold
     perturbed_cells = adata_crispr.obs_names[selected_guide.toarray().reshape(-1) >= threshold].tolist()
@@ -276,11 +279,11 @@ def _init_worker(adata):
     _WORKER_ADATA = adata
 
 
-def _fit_one(gRNA, output_dir, seed, n_iter):
-    return gRNA, fit_PGMM(gRNA, _WORKER_ADATA, output_dir, seed, n_iter)
+def _fit_one(gRNA, output_dir, seed, n_iter, make_plots):
+    return gRNA, fit_PGMM(gRNA, _WORKER_ADATA, output_dir, seed, n_iter, make_plots)
 
 
-def ga_poisson_gauss(input_file, output_dir, start_gRNA = 0, step = None, n_iter = 500, n_counts = None, UMI_threshold = 0, n_jobs = 1):
+def ga_poisson_gauss(input_file, output_dir, start_gRNA = 0, step = None, n_iter = 500, n_counts = None, UMI_threshold = 0, n_jobs = 1, make_plots = True):
     '''
     Guide assignment in which a Poisson-Gaussian mixture model is fitted to the non-zero log-transformed UMI counts
 
@@ -293,6 +296,7 @@ def ga_poisson_gauss(input_file, output_dir, start_gRNA = 0, step = None, n_iter
         n_counts (int, optional): subsample the gRNA counts per cell to a total of n_counts. If None (default), the UMI count matrix is used without any downsampling.
         UMI_threshold (int, optional): Additional UMI threshold for assigned cells which is applied after creating the initial assignment to remove cells with fewer UMI counts than this threshold (default: no additional UMI threshold)
         n_jobs (int, optional): number of worker processes used to fit gRNAs in parallel. Default 1 (serial). For n_jobs > 1, per-gRNA fits are dispatched to a process pool; results are reassembled in input order so output is identical to the serial run.
+        make_plots (bool, optional): if False, skip writing per-gRNA loss and fitted-model PNGs. Default True to preserve existing behavior. Set to False for batch / cluster runs to reduce per-worker overhead.
 
     Returns:
         None
@@ -301,9 +305,10 @@ def ga_poisson_gauss(input_file, output_dir, start_gRNA = 0, step = None, n_iter
     # If output_dir doesn't exist, the output folders are created
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
-        os.makedirs(output_dir + "fitted_model_plots/")
-        os.makedirs(output_dir + "loss_plots/")
-        print("The output directory " + output_dir +  " was created") 
+        if make_plots:
+            os.makedirs(output_dir + "fitted_model_plots/")
+            os.makedirs(output_dir + "loss_plots/")
+        print("The output directory " + output_dir +  " was created")
 
     # Load gRNA counts data
     print('Load gRNA counts')
@@ -335,12 +340,12 @@ def ga_poisson_gauss(input_file, output_dir, start_gRNA = 0, step = None, n_iter
     if n_jobs == 1:
         for gRNA in tqdm(gRNA_list):
             time.sleep(0.01)
-            fits[gRNA] = fit_PGMM(gRNA, adata_crispr, output_dir, 2024, n_iter)
+            fits[gRNA] = fit_PGMM(gRNA, adata_crispr, output_dir, 2024, n_iter, make_plots)
     else:
         with ProcessPoolExecutor(max_workers=n_jobs,
                                  initializer=_init_worker,
                                  initargs=(adata_crispr,)) as ex:
-            futures = [ex.submit(_fit_one, gRNA, output_dir, 2024, n_iter)
+            futures = [ex.submit(_fit_one, gRNA, output_dir, 2024, n_iter, make_plots)
                        for gRNA in gRNA_list]
             for fut in tqdm(futures):
                 gRNA, payload = fut.result()


### PR DESCRIPTION
## Summary

  Two optional, backwards-compatible parameters on `ga_gauss` and
  `ga_poisson_gauss` for larger / batch runs:

  - **`n_jobs`** (default `1`) — dispatches per-gRNA fits to a
    `ProcessPoolExecutor`. AnnData is passed once per worker via the pool's
    `initializer` (not pickled per task). Results are reassembled in input
    gRNA order, so output is identical regardless of `n_jobs`. With
    `n_jobs=1` the original code path is preserved.
  - **`make_plots`** (default `True`) — when `False`, skips writing the
    per-gRNA loss and fitted-model PNGs (and their subdirectories). Useful
    on cluster runs where the plots aren't consumed (e.g. benchmarking)

  No new dependencies (`concurrent.futures` is stdlib). Defaults match prior
  behavior.
  
  ## Motivation
  
  This seemed a low hanging fruit when using `crispat` for hundreds or thousands of gRNAs serially. A similar strategy can be used in other functions, can followup with new PRs if this is an interesting direction for the tool.
  
  ## Caveats
  
  Perhaps worth noting somewhere that ` OMP_NUM_THREADS=1` should be set for a large worker pool.